### PR TITLE
Prevent spurious warning about undefined values

### DIFF
--- a/lib/HTML/FormHandler/Widget/Field/Select.pm
+++ b/lib/HTML/FormHandler/Widget/Field/Select.pm
@@ -53,7 +53,7 @@ sub render {
         $output .= ' selected="selected"'
             if $self->check_selected_option($option);
         my $label = $self->localize_labels ? $self->_localize($option->{label}) : $option->{label};
-        $output .= '>' . $self->html_filter($label) . '</option>';
+        $output .= '>' . ($self->html_filter($label) || '') . '</option>';
         $index++;
     }
     $output .= '</select>';


### PR DESCRIPTION
Hi,
This patch fixes a warning about undefined values.

I'm not sure if it wouldn't be better implemented somewhere higher level though, perhaps html_filter() should always convert undefs to empty strings?

Toby
