### PR TITLE
html_prefix_separator Form attribute added, with tests and docs.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -46,6 +46,7 @@ File::ShareDir             = 0
 Try::Tiny                  = 0
 namespace::autoclean       = 0.09
 Email::Valid               = 0
+GD::SecurityImage          = 0
 
 [Prereqs / TestRequires]
 Test::More                 = 0.94

--- a/lib/HTML/FormHandler.pm
+++ b/lib/HTML/FormHandler.pm
@@ -659,7 +659,9 @@ Flag to indicate that the form name is used as a prefix for fields
 in an HTML form. Useful for multiple forms
 on the same HTML page. The prefix is stripped off of the fields
 before creating the internal field name, and added back in when
-returning a parameter hash from the 'fif' method. For example,
+returning a parameter hash from the 'fif' method.
+
+For example,
 the field name in the HTML form could be "book.borrower", and
 the field name in the FormHandler form (and the database column)
 would be just "borrower".
@@ -668,7 +670,23 @@ would be just "borrower".
    has '+html_prefix' => ( default => 1 );
 
 Also see the Field attribute "html_name", a convenience function which
-will return the form name + "." + field full_name
+will return the form name + html_prefix_separator + field full_name
+
+=head3 html_prefix_separator
+
+When html_prefix is set, this is the string which is used to connect
+the form name and the field names.
+By default it is set to "." (dot character).
+
+For example, given the above form class, by adding:
+
+   has '+html_prefix_separator' => ( default => '_' );
+
+the field name in the HTML form will be "book_borrower".
+
+This proves to be handy with DOM/CSS/jQuery selectors,
+where an (unescaped) dot inside an identifier would be interpreted
+as a metacharacter (thus making the selector not working).
 
 =head2 For use in HTML
 
@@ -771,7 +789,8 @@ has 'reload_after_update' => ( is => 'rw', isa     => 'Bool' );
 has [ 'verbose', 'processed', 'did_init_obj' ] => ( isa => 'Bool', is => 'rw' );
 has 'user_data' => ( isa => 'HashRef', is => 'rw' );
 has 'ctx' => ( is => 'rw', weak_ref => 1, clearer => 'clear_ctx' );
-has 'html_prefix'   => ( isa => 'Bool', is  => 'ro' );
+has 'html_prefix'           => ( isa => 'Bool', is  => 'ro' );
+has 'html_prefix_separator' => ( isa => 'Str',  is  => 'ro', default => '.' );
 has 'active_column' => ( isa => 'Str',  is  => 'ro' );
 has 'http_method'   => ( isa => 'Str',  is  => 'ro', default => 'post' );
 has 'enctype'       => ( is  => 'rw',   isa => 'Str' );

--- a/lib/HTML/FormHandler/Field.pm
+++ b/lib/HTML/FormHandler/Field.pm
@@ -126,7 +126,8 @@ The field accessor with all parents
 
 =item html_name
 
-The full_name plus the form name if 'html_prefix' is set.
+The full_name, prepended by the form name and the 'html_prefix_separator' if
+'html_prefix' is set.
 
 =item input_param
 
@@ -845,7 +846,8 @@ has 'html_name' => (
 
 sub build_html_name {
     my $self = shift;
-    my $prefix = ( $self->form && $self->form->html_prefix ) ? $self->form->name . "." : '';
+    my $form = $self->form;
+    my $prefix = ( $form && $form->html_prefix ) ? $form->name . $form->html_prefix_separator : '';
     return $prefix . $self->full_name;
 }
 has 'widget'            => ( isa => 'Str',  is => 'rw' );

--- a/lib/HTML/FormHandler/Fields.pm
+++ b/lib/HTML/FormHandler/Fields.pm
@@ -158,7 +158,7 @@ sub fields_fif {
     return unless $result;
     $prefix ||= '';
     if ( $self->isa('HTML::FormHandler') ) {
-        $prefix = $self->name . "." if $self->html_prefix;
+        $prefix = $self->name . $self->html_prefix_separator if $self->html_prefix;
     }
     my %params;
     foreach my $fld_result ( $result->results ) {

--- a/t/form_handler.t
+++ b/t/form_handler.t
@@ -185,5 +185,30 @@ is_deeply( $form->value, { foo => 'bovine', bar => 'horse' }, 'correct value' );
 $form = HTML::FormHandler->new( { name => 'test_form', field_list => { one => 'Text', two => 'Text' } } );
 ok( $form, 'form constructed ok' );
 
+# tests for user-defined html_prefix_separator
+
+$form = HTML::FormHandler->new( name => 'Form123', html_prefix => 1, html_prefix_separator => '_', field_list => [ 'foo' ] );
+$form->process( params => { foo => 'foovalue' } );
+is( $form->field('foo')->id, 'Form123_foo', 'right field id with custom separator' );
+is( $form->field('foo')->name, 'foo', 'right field internal with custom separator' );
+is( $form->field('foo')->html_name, 'Form123_foo', 'right field html_name with custom separator' );
+
+{
+    package My::CustomSepForm;
+    use HTML::FormHandler::Moose;
+    extends 'HTML::FormHandler';
+
+    has '+name' => ( default => 'Form123' );
+    has '+html_prefix' => ( default => 1 );
+    has '+html_prefix_separator' => ( default => '::' );
+
+    has_field 'foo';
+}
+
+$form = My::CustomSepForm->new;
+$form->process( params => { foo => 'foovalue' } );
+is( $form->field('foo')->id, 'Form123::foo', 'right field id with custom separator in a form class' );
+is( $form->field('foo')->name, 'foo', 'right field internal with custom separator in a form class' );
+is( $form->field('foo')->html_name, 'Form123::foo', 'right field html_name with custom separator in a form class' );
 
 done_testing;


### PR DESCRIPTION
A `.` (dot)  inside an identifier creates problems with DOM/CSS/jQuery selectors, since it (among many others) will be interpreted as a metacharacter, eg: a form field with the following html id: `myform.myfield` won't be selected by `$("#myform.myfield")` in jQuery.

That's why it would be useful to have the possibility to customize the string used to connect the form name and the field names when `html_prefix` is set, instead of always inserting a dot.

Of course that could be sidestepped both at the Perl level (eg. by means of method modifiers) or at the javascript level (by escaping the metacharacters inside the identifiers), but providing a user-customizable `html_prefix_separator` as a form attribute is a much handier solution.

Of course the `html_prefix_separator` **default value has been set to** `.`, so no harm will be caused to existing code.

Tests and docs have been added.

The same problem affected ASP.NET as well (though I'm not sure that a solution has ever been provided :-) [Link](http://aspnet.codeplex.com/workitem/2403?ProjectName=aspnet)

(The seemingly missing `GD::SecurityImage` prereq has been added to `dist.ini` as well: please discard it in case it was intentional).

Thank you for your invaluable work!
-Emanuele
