### PR TITLE
Field::TextArea extends Field::Text to reuse its validations (min/max length)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+    Field::TextArea extends Field::Text to reuse its validations (min/max length)
+
 0.35005 Sat Oct 8, 2011
     Fix bug repeatable result not returned for num_when_empty
     Fix bug repeatable required flag not propagated

--- a/lib/HTML/FormHandler/Field/TextArea.pm
+++ b/lib/HTML/FormHandler/Field/TextArea.pm
@@ -2,8 +2,8 @@ package HTML::FormHandler::Field::TextArea;
 # ABSTRACT: textarea input
 
 use Moose;
-extends 'HTML::FormHandler::Field';
-our $VERSION = '0.01';
+extends 'HTML::FormHandler::Field::Text';
+our $VERSION = '0.02';
 
 has '+widget' => ( default => 'textarea' );
 has 'cols'    => ( isa     => 'Int', is => 'rw' );
@@ -11,7 +11,7 @@ has 'rows'    => ( isa     => 'Int', is => 'rw' );
 
 =head1 Summary
 
-For HTML textarea. Uses 'textarea' widget. Set cols/row.
+For HTML textarea. Uses 'textarea' widget. Set cols/row/minlenght/maxlength.
 
 =cut
 

--- a/t/fields.t
+++ b/t/fields.t
@@ -426,6 +426,10 @@ ok( $field, 'get TextArea field');
 $field->_set_input("Testing, testing, testing... This is a test");
 $field->validate_field;
 ok( !$field->has_errors, 'field has no errors');
+$field->maxlength( 10 );
+$field->validate_field;
+ok( $field->has_errors, 'field has errors');
+is( $field->errors->[0], 'Field should not exceed 10 characters. You entered 43',  'Test for too long' );
 
 # text
 


### PR DESCRIPTION
This little change allow people use minlength and maxlegth validations from Field::Text in Field::TextArea.

Have a look and let me know.

Thanks,
- CMM
