### PR TITLE
Fix for RT #74664

### DIFF
--- a/lib/HTML/FormHandler/Widget/Field/RadioGroup.pm
+++ b/lib/HTML/FormHandler/Widget/Field/RadioGroup.pm
@@ -22,7 +22,9 @@ sub render {
             if $fif eq $value;
         $output .= process_attrs($self->element_attributes($result));
         $output .= ' />';
-        $output .= $self->html_filter($option->{label}) . '</label><br />';
+        my $label = $option->{label};
+        $label = $self->_localize($label) if $self->localize_labels;
+        $output .= $self->html_filter($label) . '</label><br />';
         $index++;
     }
     return $self->wrap_field( $result, $output );


### PR DESCRIPTION
HTML::FormHandler::Widget::Field::RadioGroup didn't localize labels
