### PR TITLE
Localize the value of the reset button

### DIFF
--- a/lib/HTML/FormHandler/Widget/Field/Reset.pm
+++ b/lib/HTML/FormHandler/Widget/Field/Reset.pm
@@ -12,7 +12,7 @@ sub render {
     my $output = '<input type="reset" name="';
     $output .= $self->html_name . '"';
     $output .= ' id="' . $self->id . '"';
-    $output .= ' value="' . $self->html_filter($self->value) . '"';
+    $output .= ' value="' . $self->html_filter($self->_localize($self->value)) . '"';
     $output .= process_attrs($self->element_attributes($result));
     $output .= ' />';
     return $self->wrap_field( $result, $output );


### PR DESCRIPTION
All buttons have localized values except the reset button.  I think this is a bug.
