### PR TITLE
Button opening tag shouldn't end with `/>`

### DIFF
--- a/lib/HTML/FormHandler/Widget/Field/ButtonTag.pm
+++ b/lib/HTML/FormHandler/Widget/Field/ButtonTag.pm
@@ -13,7 +13,7 @@ sub render {
     my $output = '<button type="' . $self->input_type . '" name="'
         . $self->html_name . '" id="' . $self->id . '"';
     $output .= process_attrs($self->element_attributes($result));
-    $output .= '/>';
+    $output .= '>';
     $output .= $self->_localize($self->value);
     $output .= "</button>";
 


### PR DESCRIPTION
Produces invalid HTML which sometimes won't be displayed correctly.
