### PR TITLE
has_form returns 1 but the field->form can be undefined with Repeatable::Instances

### DIFF
--- a/lib/HTML/FormHandler/Field.pm
+++ b/lib/HTML/FormHandler/Field.pm
@@ -1139,7 +1139,7 @@ sub language_handle {
         return;
     }
     return $self->get_language_handle if( $self->has_language_handle );
-    return $self->form->language_handle if ( $self->has_form );
+    return $self->form->language_handle if ( $self->form );
     require HTML::FormHandler::I18N;
     return $ENV{LANGUAGE_HANDLE} || HTML::FormHandler::I18N->get_handle;
 }


### PR DESCRIPTION
Gerda:

Here is a tiny patch that I actually ran across at work, while trying to fix the CE::Form::Admin::College::FacebookPages::Test. This, HTML::FormHandler::Field, line 607:

``` perl
    return $self->form->language_handle if ( $self->has_form );
```

Always tries to use the form->language_handle, but the form is undef, so it fails and so does the test. I didn't know what the difference between 0.40010 and 0.40011 was that caused it, but this is change seemed economical.
