### PR TITLE
HTML::FH::Widget::Field::Span - fixed starting tag

### DIFF
--- a/lib/HTML/FormHandler/Widget/Field/Span.pm
+++ b/lib/HTML/FormHandler/Widget/Field/Span.pm
@@ -20,7 +20,7 @@ sub render_element {
     my $output = '<span';
     $output .= ' id="' . $self->id . '"';
     $output .= process_attrs($self->element_attributes($result));
-    $output .= ' />';
+    $output .= '>';
     $output .= $self->value;
     $output .= '</span>';
     return $output;


### PR DESCRIPTION
Starting tag should not be considered a void tag!
