### PR TITLE
Tiny little edit: Adding an apparently missing line to a Manual::Validation example.

### DIFF
--- a/lib/HTML/FormHandler/Manual/Validation.pod
+++ b/lib/HTML/FormHandler/Manual/Validation.pod
@@ -127,6 +127,7 @@ perform this validation when a particular field is a particular value:
     has_field 'fee';
     has_field 'fie' => ( apply => [
         { when => { fee => 1 }, check => qr/when/, message => 'Wrong fie' },
+    ]);
     has_field 'fo';
     has_field 'fum_comp' => ( type => 'Compound' );
     has_field 'fum_comp.one';


### PR DESCRIPTION
Adding some missing close-brackets to a code example.
