### PR TITLE
new abstract method for FH::Model : ->item_values

### DIFF
--- a/lib/HTML/FormHandler/Model.pm
+++ b/lib/HTML/FormHandler/Model.pm
@@ -164,5 +164,17 @@ Update the model with validated fields
 
 sub update_model { }
 
+=head2 item_values
+
+    $self->item_values->{id};
+
+The current values, in the form of a hashref, that the L</item>
+has.  Used to abstract details of how to access the raw values of
+a given model.
+
+=cut
+
+sub item_values { } 
+
 use namespace::autoclean;
 1;

--- a/lib/HTML/FormHandler/Result.pm
+++ b/lib/HTML/FormHandler/Result.pm
@@ -46,7 +46,7 @@ Dynamic select lists are not supported yet. Static select lists
 (that are the same for every form execution) should work fine, but lists
 that are different depending on some field value will not.
 
-Most of this object is implemented in L<HTML::FormHandler::Role::Result>,
+Most of this object is implemented in L<HTML::FormHandler::Result::Role>,
 because it is shared with L<HTML::FormHandler::Field::Result>.
 
 =cut
@@ -55,6 +55,7 @@ has 'form' => (
     isa      => 'HTML::FormHandler',
     is       => 'ro',
     weak_ref => 1,
+    handles  => ['item_values'],
     #  handles => ['render' ]
 );
 


### PR DESCRIPTION
In order to abstract how a concrete model (such as FH:Model::DBIC) exposes its internal, raw view of its current data, add a new abstract method on FH:Model called 'item_values', which is expected to be a read only accessor that is a hash ref of field/values.  Concrete types of this model should do something sane with this method.

This avoids any need for hard structural bindings between FH and a given type of model in the case where you want to access the model data, such as when after an insert the DBIC model will have autogenerated PKs, default values that are not otherwise default in the Form, or other types of generated data.

Current example use case for this : https://github.com/jjn1056/CatalystX-Example-Todo/blob/master/lib/CatalystX/Example/Todo/Web/Controller/API.pm#L27 which is a case where I want to return as JSON the database PK and a default column 'status', which the Form itself knows nothing about.  In the linked case the only way to get this data is by reaching down into form->item and called a model specific method, which breaks encapsulation and unnecessarily exposes the controller to model specific details.
