### PR TITLE
List::AllUtils version number fix

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -53,7 +53,7 @@ HTML::TreeBuilder          = 3.23
 Sub::Name                  = 0
 Data::Clone                = 0
 JSON                       = 0
-List::AllUtils             = 0.7
+List::AllUtils             = 0.07
 
 [Prereqs / TestRequires]
 Test::More                 = 0.94


### PR DESCRIPTION
Which handles this:
Configuring HTML-FormHandler-0.40052 ... OK
==> Found dependencies: List::AllUtils
Found List::AllUtils 0.07 which doesn't satisfy 0.7.
! Installing the dependencies failed: Installed version (0.07) of List::AllUtils is not in range '0.7'
! Bailing out the installation for HTML-FormHandler-0.40052.
