### PR TITLE
Use alert-danger rather than alert-error with in the Bootstrap3.

### DIFF
--- a/lib/HTML/FormHandler/Widget/Theme/Bootstrap3.pm
+++ b/lib/HTML/FormHandler/Widget/Theme/Bootstrap3.pm
@@ -44,4 +44,6 @@ after 'before_build' => sub {
 
 sub build_form_element_class { ['form-horizontal'] }
 
+sub form_messages_alert_error_class { 'alert-danger' }
+
 1;

--- a/lib/HTML/FormHandler/Widget/Theme/BootstrapFormMessages.pm
+++ b/lib/HTML/FormHandler/Widget/Theme/BootstrapFormMessages.pm
@@ -19,7 +19,8 @@ sub render_form_messages {
     $result ||= $self->result;
     my $output = '';
     if ( $result->has_form_errors || $result->has_errors ) {
-        $output = qq{\n<div class="alert alert-error">};
+        my $alert_error_class = $self->form_messages_alert_error_class;
+        $output = qq{\n<div class="alert $alert_error_class">};
         my $msg = $self->error_message;
         $msg ||= 'There were errors in your form';
         $msg = $self->_localize($msg);
@@ -45,5 +46,7 @@ sub render_form_messages {
     }
     return $output;
 }
+
+sub form_messages_alert_error_class { 'alert-error' }
 
 1;


### PR DESCRIPTION
Hello.

alert-error has been changed in the Bootstrap 3.0.
http://getbootstrap.com/getting-started/#migration-classes

Please merge if it is good.
