### PR TITLE
Fixes RT#91966 (deprecated way to call enum warning)

### DIFF
--- a/t/validation/constraints.t
+++ b/t/validation/constraints.t
@@ -34,7 +34,7 @@ use lib 't/lib';
        => from 'Str'
          => via { 0+$_ };
 
-   enum 'RGBColors' => qw(red green blue);
+   enum 'RGBColors' => [ qw(red green blue) ];
 
    no Moose::Util::TypeConstraints;
 


### PR DESCRIPTION
This is a fix for RT#91966: https://rt.cpan.org/Ticket/Display.html?id=91966
