### PR TITLE
Respect label_no_filter on checkbox labels.

### DIFF
--- a/lib/HTML/FormHandler/Widget/Wrapper/Base.pm
+++ b/lib/HTML/FormHandler/Widget/Wrapper/Base.pm
@@ -95,10 +95,10 @@ sub get_checkbox_label {
 
     my $label =  $self->option_label || '';
     if( $label eq '' && ! $self->do_label ) {
-        $label = $self->html_filter($self->loc_label);
+        $label = $self->get_tag('label_no_filter') ? $self->loc_label : $self->html_filter($self->loc_label);
     }
     elsif( $label ne '' ) {
-        $label = $self->html_filter($self->_localize($label));
+        $label = $self->get_tag('label_no_filter') ? $self->_localize($label) : $self->html_filter($self->_localize($label));
     }
     return $label;
 }

--- a/lib/HTML/FormHandler/Widget/Wrapper/Bootstrap3.pm
+++ b/lib/HTML/FormHandler/Widget/Wrapper/Bootstrap3.pm
@@ -158,7 +158,7 @@ sub wrap_checkbox {
 
     # use the regular label
     my $label =  $self->option_label || $self->label;
-    $label = $self->html_filter($self->_localize($label));
+    $label = $self->get_tag('label_no_filter') ? $self->_localize($label) : $self->html_filter($self->_localize($label));
     my $id = $self->id;
     my $for = qq{ for="$id"};
 


### PR DESCRIPTION
Add code to respect the label_no_filter tag on checkboxes for Bootstrap and the Base widgets.

Bug demonstrated by having :

```
has_field 'agree_to_terms' => (
    type => 'Boolean',
    required => 1,
    label => 'I agree to the <a href="/terms" target="_new">Terms and Conditions</a>.',
    tags => { label_no_filter => 1 },
    required_message => 'You must agree to the Terms and Conditions.',
);
```
