### PR TITLE
Adding HTML5 format restrictions for Date fields

### DIFF
--- a/lib/HTML/FormHandler/Field/Date.pm
+++ b/lib/HTML/FormHandler/Field/Date.pm
@@ -47,8 +47,26 @@ Customize error messages 'date_early' and 'date_late':
        messages => { date_early => 'Pick a later date',
                      date_late  => 'Pick an earlier date', } );
 
-If form has 'is_html5' flag active it will render <input type="date" ... />
-instead of type="text"
+=head2 Using with HTML5
+
+If the field's form has its 'is_html5' flag active, then the field's rendering
+behavior changes in two ways:
+
+=over
+
+=item *
+
+It will render as <input type="date" ... /> instead of type="text".
+
+=item *
+
+If the field's format is set to anything other than ISO date format
+(%Y-%m-%d), then attempting to render the field will result in a fatal error.
+
+(Note that the default value for the field's format attribute is, in fact,
+the ISO date format.)
+
+=back
 
 =cut
 
@@ -147,6 +165,23 @@ sub get_strf_format {
         $format =~ s/\%5/\%{day_of_month}/g,
         return $format;
 }
+
+before 'get_tag' => sub {
+    my $self = shift;
+
+    if (
+        $self->form
+        && $self->form->is_html5
+        && not( $self->format =~ /^(yy|%Y)-(mm|%m)-(dd|%d)$/ )
+    ) {
+        die "Form is HTML5, but date field '"
+            . $self->full_name
+            . "' has a format other than %Y-%m-%d, which HTML5 requires for date "
+            . "fields. Either set its format to this, "
+            . "or use its default format (which is also this), or set the form's "
+            . "'is_html5' flag to false.";
+    }
+};
 
 __PACKAGE__->meta->make_immutable;
 use namespace::autoclean;

--- a/t/fields/dates.t
+++ b/t/fields/dates.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use Test::Exception;
 
 
 use HTML::FormHandler::I18N;
@@ -180,5 +181,48 @@ $fif->{'my_date.day'} = '15';
 $form->process( params => $fif );
 ok( $form->validated, 'form validated' );
 is( $form->field('my_date')->value->mdy, '02-15-2010', 'right value for my_date' );
+
+#
+# HTML5 date-format restrictions
+#
+{
+   package Test::Date::HTML5;
+   use HTML::FormHandler::Moose;
+   extends 'HTML::FormHandler';
+   with 'HTML::FormHandler::Render::Simple';
+
+   has '+is_html5' => ( default => 1 );
+   has_field 'date' => ( type => 'Date', format => 'mm/dd/yy');
+}
+
+throws_ok(
+    sub { $form = Test::Date::HTML5->new; $form->render; },
+    qr/HTML5 requires for date fields/,
+    "Refusal to render an HTML5 form with a non-ISO date format",
+);
+
+{
+   package Test::Date::HTML5;
+   has_field '+date' => ( format => 'yy-mm-dd' );
+}
+
+lives_ok(
+    sub { $form = Test::Date::HTML5->new; $form->render; },
+    "HTML5 renders fine with ISO date format",
+);
+
+{
+   package Test::Date::HTML5::WithDefault;
+   use HTML::FormHandler::Moose;
+   extends 'HTML::FormHandler';
+   with 'HTML::FormHandler::Render::Simple';
+
+   has_field 'date' => ( type => 'Date' );
+}
+
+lives_ok(
+    sub { $form = Test::Date::HTML5->new; $form->render; },
+    "HTML5 renders fine with default date format",
+);
 
 done_testing;

--- a/t/fields/dates.t
+++ b/t/fields/dates.t
@@ -221,7 +221,7 @@ lives_ok(
 }
 
 lives_ok(
-    sub { $form = Test::Date::HTML5->new; $form->render; },
+    sub { $form = Test::Date::HTML5::WithDefault->new; $form->render; },
     "HTML5 renders fine with default date format",
 );
 


### PR DESCRIPTION
The HTML5 "date" field type always and only formats its date in ISO format (YYYY-MM-DD). I have therefore added a restriction to the Date field class such that, if its parent form has its is_html5 flag set, _and_ its format attribute is anything other than ISO, then it dies with an appropriate complaint.

I have also updated the POD and tests appropriately.

Finding the right place to put the new validation code was an interesting challenge. I decided that  rendering-time was the right time to check, and `get_tag` seemed as good a method to wrap the validator around as any (since straight-up modifying `render` doesn't seem to be an option?)