### PR TITLE
Changing the HTML5 tag-text of Integer fields to "tel".

### DIFF
--- a/lib/HTML/FormHandler/Field/Integer.pm
+++ b/lib/HTML/FormHandler/Field/Integer.pm
@@ -6,7 +6,7 @@ extends 'HTML::FormHandler::Field::Text';
 our $VERSION = '0.02';
 
 has '+size' => ( default => 8 );
-has '+html5_type_attr' => ( default => 'number' );
+has '+html5_type_attr' => ( default => 'tel' );
 
 our $class_messages = {
     'integer_needed' => 'Value must be an integer',
@@ -46,7 +46,7 @@ This accepts a positive or negative integer.  Negative integers may
 be prefixed with a dash.  By default a max of eight digits are accepted.
 Widget type is 'text'.
 
-If form has 'is_html5' flag active it will render <input type="number" ... />
+If form has 'is_html5' flag active it will render <input type="tel" ... />
 instead of type="text"
 
 The 'range_start' and 'range_end' attributes may be used to limit valid numbers.


### PR DESCRIPTION
This is an opinionated change proposal.

According to a designer I've been working with, and backed up by discussion found around the web (e.g. [on Stack Overflow](http://stackoverflow.com/questions/8216278/html5-input-type-number-vs-tel) and [http://mobileinputtypes.com](http://mobileinputtypes.com)), `tel` is a more practically effective HTML5 input type when dealing with fields meant to only accept digits, versus `number`. This is especially true on mobile, where `tel` presents the user with a telephone-style keypad, and `number` doesn't. (On iOS, for instance, `number` pops up the usual system alpha-numeric keyboard.)