### PR TITLE
Validation

### DIFF
--- a/lib/HTML/FormHandler/Validate.pm
+++ b/lib/HTML/FormHandler/Validate.pm
@@ -175,8 +175,8 @@ sub _apply_actions {
     };
 
     my $is_type = sub {
-        my $ref = ref shift;
-        return $ref eq 'MooseX::Types::TypeDecorator' || $ref eq 'Type::Tiny';
+        my $class = blessed shift or return;
+        return $class eq 'MooseX::Types::TypeDecorator' || $class->isa('Type::Tiny');
     };
 
     for my $action ( @{ $self->actions || [] } ) {

--- a/lib/HTML/FormHandler/Validate.pm
+++ b/lib/HTML/FormHandler/Validate.pm
@@ -173,13 +173,19 @@ sub _apply_actions {
         $error_message = $error;
         return 1;
     };
+
+    my $is_type = sub {
+        my $ref = ref shift;
+        return $ref eq 'MooseX::Types::TypeDecorator' || $ref eq 'Type::Tiny';
+    };
+
     for my $action ( @{ $self->actions || [] } ) {
         $error_message = undef;
         # the first time through value == input
         my $value     = $self->value;
         my $new_value = $value;
         # Moose constraints
-        if ( !ref $action || ref $action eq 'MooseX::Types::TypeDecorator' || ref $action eq 'Type::Tiny' ) {
+        if ( !ref $action || $is_type->($action) ) {
             $action = { type => $action };
         }
         if ( my $when = $action->{when} ) {
@@ -187,7 +193,7 @@ sub _apply_actions {
         }
         if ( exists $action->{type} ) {
             my $tobj;
-            if ( ref $action->{type} eq 'MooseX::Types::TypeDecorator' || ref $action->{type} eq 'Type::Tiny' ) {
+            if ( $is_type->($action->{type}) ) {
                 $tobj = $action->{type};
             }
             else {

--- a/t/validation/types.t
+++ b/t/validation/types.t
@@ -144,13 +144,20 @@ while (my ($name, $type, $trans) = splice @test, 0, 3) {
 SKIP: {
     eval { require Type::Tiny };
 
-    skip "Type::Tiny not installed", 9 if $@;
+    skip "Type::Tiny not installed", 15 if $@;
 
     {
         package Test::Form::Type::Tiny;
 
         use HTML::FormHandler::Moose;
         extends 'HTML::FormHandler';
+
+        use Type::Tiny::Enum;
+        my $ENUM = Type::Tiny::Enum->new(
+            name    => "Meta",
+            values  => [qw( foo bar )],
+            message => sub { "$_ ain't meta" },
+        );
 
         my $NUM = Type::Tiny->new(
             name       => "Number",
@@ -160,6 +167,8 @@ SKIP: {
 
         has_field 'test_a' => ( apply => [ $NUM ] );
         has_field 'test_b' => ( apply => [ { type => $NUM } ] );
+        has_field 'test_c' => ( apply => [ $ENUM ] );
+        has_field 'test_d' => ( apply => [ { type => $ENUM } ] );
     }
 
     my $form = Test::Form::Type::Tiny->new;
@@ -169,22 +178,32 @@ SKIP: {
     my $params = {
         test_a => 'str1',
         test_b => 'str2',
+        test_c => 'str3',
+        test_d => 'str4',
     };
     $form->process($params);
     ok( !$form->validated, 'form did not validate' );
     ok( $form->field('test_a')->has_errors, 'errors on Type::Tiny type');
     ok( $form->field('test_b')->has_errors, 'errors on Type::Tiny type');
+    ok( $form->field('test_c')->has_errors, 'errors on Type::Tiny::Enum type');
+    ok( $form->field('test_d')->has_errors, 'errors on Type::Tiny::Enum type');
     is( $form->field('test_a')->errors->[0], "str1 ain't a number", 'error from Type::Tiny' );
     is( $form->field('test_b')->errors->[0], "str2 ain't a number", 'error from Type::Tiny' );
+    is( $form->field('test_c')->errors->[0], "str3 ain't meta", 'error from Type::Tiny::Enum' );
+    is( $form->field('test_d')->errors->[0], "str4 ain't meta", 'error from Type::Tiny::Enum' );
 
     $params = {
         test_a => '123',
         test_b => '456',
+        test_c => 'foo',
+        test_d => 'bar',
     };
     $form->process($params);
     ok( $form->validated, 'form validated' );
     ok( !$form->field('test_a')->has_errors, 'no errors on Type::Tiny type');
     ok( !$form->field('test_b')->has_errors, 'no errors on Type::Tiny type');
+    ok( !$form->field('test_c')->has_errors, 'no errors on Type::Tiny::Enum type');
+    ok( !$form->field('test_d')->has_errors, 'no errors on Type::Tiny::Enum type');
 }
 
 done_testing;


### PR DESCRIPTION
Update HTML::FormHandler::Validate to detect and use subclasses of Type::Tiny constraints, such as Type::Tiny::Class or Type::Tiny::Enum