### PR TITLE
Don't warn about date format unless set to `date`

### DIFF
--- a/lib/HTML/FormHandler/Field/Date.pm
+++ b/lib/HTML/FormHandler/Field/Date.pm
@@ -172,6 +172,7 @@ before 'get_tag' => sub {
     if (
         $self->form
         && $self->form->is_html5
+        && $self->html5_type_attr eq 'date' # subclass may be using different input type
         && not( $self->format =~ /^(yy|%Y)-(mm|%m)-(dd|%d)$/ )
     ) {
         warn "Form is HTML5, but date field '" . $self->full_name


### PR DESCRIPTION
Subclass may be using different input type (eg. to avoid UI confusion with using a datepicker widget).

Signed-off-by: Charlie Garrison <cngarrison@gmail.com>