### PR TITLE
Wrap checkbox in CheckboxGroup, if requested

### DIFF
--- a/lib/HTML/FormHandler/Widget/Field/CheckboxGroup.pm
+++ b/lib/HTML/FormHandler/Widget/Field/CheckboxGroup.pm
@@ -103,6 +103,10 @@ sub render_option {
     $output .= $self->html_filter($label);
     $output .= "\n</label>";
     $self->inc_options_index;
+
+    if ($self->get_tag('checkbox_element_wrapper')) {
+        $output = qq{<div class="checkbox">$output</div>};
+    }
     return $output;
 }
 

--- a/t/bootstrap3/controls.t
+++ b/t/bootstrap3/controls.t
@@ -25,9 +25,15 @@ my $expected = '
 <div class="form-group">
   <label class="control-label" for="inlineCheckboxes">Inline checkboxes</label>
   <div>
-    <label class="checkbox checkbox-inline" for="inlineCheckboxes.0"><input id="inlineCheckboxes.0" name="inlineCheckboxes" type="checkbox" value="option1" /> 1 </label>
-    <label class="checkbox checkbox-inline" for="inlineCheckboxes.1"><input id="inlineCheckboxes.1" name="inlineCheckboxes" type="checkbox" value="option2" /> 2 </label>
-    <label class="checkbox checkbox-inline" for="inlineCheckboxes.2"><input id="inlineCheckboxes.2" name="inlineCheckboxes" type="checkbox" value="option3" /> 3 </label>
+    <div class="checkbox">
+      <label class="checkbox checkbox-inline" for="inlineCheckboxes.0"><input id="inlineCheckboxes.0" name="inlineCheckboxes" type="checkbox" value="option1" /> 1 </label>
+    </div>
+    <div class="checkbox">
+      <label class="checkbox checkbox-inline" for="inlineCheckboxes.1"><input id="inlineCheckboxes.1" name="inlineCheckboxes" type="checkbox" value="option2" /> 2 </label>
+    </div>
+    <div class="checkbox">
+      <label class="checkbox checkbox-inline" for="inlineCheckboxes.2"><input id="inlineCheckboxes.2" name="inlineCheckboxes" type="checkbox" value="option3" /> 3 </label>
+    </div>
   </div>
 </div>
 ';


### PR DESCRIPTION
My CheckboxGroup's labels were all bold

That's because it hadn't been wrapped in `<div class="checkbox">`

Now it is