### PR TITLE
Ensure Text fields only contain a single value

### DIFF
--- a/lib/HTML/FormHandler/Field/Text.pm
+++ b/lib/HTML/FormHandler/Field/Text.pm
@@ -19,6 +19,7 @@ has '+widget' => ( default => 'Text' );
 our $class_messages = {
     'text_maxlength' => 'Field should not exceed [quant,_1,character]. You entered [_2]',
     'text_minlength' => 'Field must be at least [quant,_1,character]. You entered [_2]',
+    'multiple_values_disallowed' => 'Field must contain a single value',
 };
 
 sub get_class_messages {
@@ -53,6 +54,13 @@ sub validate {
             $field->get_message('text_minlength'),
             $minlength, length $value, $field->loc_label )
             if length $value < $minlength;
+    }
+
+    # Check for multiple values
+    if ( ref $value eq 'ARRAY' ) {
+        return $field->add_error(
+            $field->get_message('multiple_values_disallowed'),
+        );
     }
     return 1;
 }

--- a/t/validation/types.t
+++ b/t/validation/types.t
@@ -65,6 +65,20 @@ ok( !$form->field('text_gt')->has_errors, 'no errors on subtype');
 ok( !$form->field('text_both')->has_errors, 'no errors on both');
 ok( !$form->field('state')->has_errors, 'no errors on state' );
 
+$params = {
+   test => 100,
+   text_gt => 21,
+   text_both => 15,
+   state => [ qw(NY IL) ],
+};
+
+$form->process($params);
+ok( !$form->validated, 'form did not validate' );
+ok( !$form->field('test')->has_errors, 'no errors on MooseX type');
+ok( !$form->field('text_gt')->has_errors, 'no errors on subtype');
+ok( !$form->field('text_both')->has_errors, 'no errors on both');
+ok( $form->field('state')->has_errors, 'errors on state' );
+
 # State
 my $field = HTML::FormHandler::Field->new( name => 'Test1', apply => [ State ] );
 $field->build_result;


### PR DESCRIPTION
Before this change, submitting a form with parameters like
"?field=value1&field=value2" resulted in setting a Text field to
something like ARRAY(0x...).  Now, the field fails validation.