### PR TITLE
Add comma digit grouping and custom currency symbol

### DIFF
--- a/lib/HTML/FormHandler/Field/Money.pm
+++ b/lib/HTML/FormHandler/Field/Money.pm
@@ -79,6 +79,25 @@ Uses a period for the decimal point. Widget type is 'text'.
 If form has 'is_html5' flag active it will render <input type="number" ... />
 instead of type="text"
 
+
+=head1 ATTRIBUTES
+
+=head2
+
+=over
+
+=item currency_symbol
+
+Currency symbol to remove from start of input if found, default is dollar
+C<$>.
+
+=item allow_commas
+
+Allow commas in input for digit grouping? Digits are grouped into groups of 3,
+for example C<1,000,000,000>. Defaults to I<false>.
+
+=back
+
 =cut
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/HTML/FormHandler/Field/Money.pm
+++ b/lib/HTML/FormHandler/Field/Money.pm
@@ -6,6 +6,16 @@ extends 'HTML::FormHandler::Field::Text';
 our $VERSION = '0.01';
 
 has '+html5_type_attr' => ( default => 'number' );
+has 'currency_symbol' => (
+    is      => 'ro',
+    isa     => 'Str',
+    default => '$',
+);
+has 'allow_commas' => (
+    is      => 'ro',
+    isa     => 'Bool',
+    default => 0,
+);
 
 our $class_messages = {
     'money_convert' => 'Value cannot be converted to money',
@@ -21,30 +31,43 @@ sub get_class_messages  {
 }
 
 apply(
-    [
-        {
+    [   {   # remove any leading currency symbol
             transform => sub {
-                my $value = shift;
-                $value =~ s/^\$//;
+                my ( $value, $field ) = @_;
+                my $c = $field->currency_symbol;
+                $value =~ s/^\Q$c\E// if $c;
                 return $value;
-                }
+            },
         },
-        {
+        {   # check number looks real, optionally allow comma digit groupings
+            check => sub {
+                my ( $value, $field ) = @_;
+                return $field->allow_commas
+                     ? $value =~ /^[-+]?(?:\d+|\d{1,3}(,\d{3})*)(?:\.\d+)?$/
+                     : $value =~ /^[-+]?\d+(?:\.\d+)?$/;
+            },
+            message => sub {
+                my ( $value, $field ) = @_;
+                return [ $field->get_message('money_real'), $value ];
+            },
+        },
+        {   # remove commas
+            transform => sub {
+                my ($value, $field) = @_;
+                $value =~ tr/,//d if $field->allow_commas;
+                return $value;
+            },
+        },
+        {   # convert to standard number, formatted to 2 decimal palaces
             transform => sub { sprintf '%.2f', $_[0] },
-            message => sub {
+            message   => sub {
                 my ( $value, $field ) = @_;
-                return [$field->get_message('money_convert'), $value];
+                return [ $field->get_message('money_convert'), $value ];
             },
         },
-        {
-            check => sub { $_[0] =~ /^-?\d+\.?\d*$/ },
-            message => sub {
-                my ( $value, $field ) = @_;
-                return [$field->get_message('money_real'), $value];
-            },
-        }
     ]
 );
+
 
 =head1 DESCRIPTION
 

--- a/t/fields/fields.t
+++ b/t/fields/fields.t
@@ -235,7 +235,7 @@ ok( $field->has_errors, 'Test for errors "   $12,345.67  "' );
 is( $field->errors->[0], 'Value must be a real number', 'get error' );
 $field->_set_input( "   \N{POUND SIGN}12,345.67  " );
 $field->validate_field;
-ok( $field->has_errors, 'Test for errors "   \N{POUND SIGN}12345.67  "' );
+ok( $field->has_errors, 'Test for errors "   \N{POUND SIGN}12,345.67  "' );
 is( $field->errors->[0], 'Value must be a real number', 'get error' );
 $field = $class->new( 
     name    => 'test_field', 
@@ -246,7 +246,7 @@ $field->build_result;
 ok( defined $field,  'new() called' );
 $field->_set_input( "   \N{POUND SIGN}12,345.67  " );
 $field->validate_field;
-ok( !$field->has_errors, 'Test for errors "   \N{POUND SIGN}12345.67  "' );
+ok( !$field->has_errors, 'Test for errors "   \N{POUND SIGN}12,345.67  "' );
 
 
 # monthday

--- a/t/fields/fields.t
+++ b/t/fields/fields.t
@@ -3,6 +3,8 @@ use warnings;
 
 use Test::More;
 
+use charnames ':full';
+
 use HTML::FormHandler::I18N;
 $ENV{LANGUAGE_HANDLE} = 'en_en';
 
@@ -223,10 +225,28 @@ is( $field->value, 123.45, 'Test value == 123.45' );
 $field->_set_input( '   $12x3.45  ' );
 $field->validate_field;
 ok( $field->has_errors, 'Test for errors "   $12x3.45  "' );
-is( $field->errors->[0], 'Value cannot be converted to money', 'get error' );
+is( $field->errors->[1], 'Value cannot be converted to money', 'get error' );
 $field->_set_input( 2345 );
 $field->validate_field;
 is( $field->value, '2345.00', 'transformation worked: 2345 => 2345.00' );
+$field->_set_input( '   $12,345.67  ' );
+$field->validate_field;
+ok( $field->has_errors, 'Test for errors "   $12,345.67  "' );
+is( $field->errors->[0], 'Value must be a real number', 'get error' );
+$field->_set_input( "   \N{POUND SIGN}12,345.67  " );
+$field->validate_field;
+ok( $field->has_errors, 'Test for errors "   \N{POUND SIGN}12345.67  "' );
+is( $field->errors->[0], 'Value must be a real number', 'get error' );
+$field = $class->new( 
+    name    => 'test_field', 
+    currency_symbol => "\N{POUND SIGN}", 
+    allow_commas => 1,
+);
+$field->build_result;
+ok( defined $field,  'new() called' );
+$field->_set_input( "   \N{POUND SIGN}12,345.67  " );
+$field->validate_field;
+ok( !$field->has_errors, 'Test for errors "   \N{POUND SIGN}12345.67  "' );
 
 
 # monthday


### PR DESCRIPTION
Default behavior is the same as the existing module. Although the order in which the number is validated and converted has been switched so that the input is validated before the conversion is attempted. This made more sense when the additional conversion steps where added.