### PR TITLE
Allow deflation methods to run on undef values

### DIFF
--- a/lib/HTML/FormHandler/Field.pm
+++ b/lib/HTML/FormHandler/Field.pm
@@ -669,25 +669,26 @@ sub fif {
 
     return if ( $self->inactive && !$self->_active );
     return '' if $self->password;
-    return unless $result || $self->has_result;
+
     my $lresult = $result || $self->result;
     if ( ( $self->has_result && $self->has_input && !$self->fif_from_value ) ||
         ( $self->fif_from_value && !defined $lresult->value ) )
     {
         return defined $lresult->input ? $lresult->input : '';
     }
-    if ( defined $lresult->value ) {
+    if ( $lresult ) {
+        if ( not defined $lresult->value and defined $self->value ) {
+            # this is because checkboxes and submit buttons have their own 'value'
+            # needs to be fixed in some better way
+            return $self->value;
+        }
+
         if( $self->_can_deflate ) {
-            return $self->_apply_deflation($lresult->value);
+            return ($self->_apply_deflation($lresult->value) // '');
         }
         else {
-            return $lresult->value;
+            return ($lresult->value // '');
         }
-    }
-    elsif ( defined $self->value ) {
-        # this is because checkboxes and submit buttons have their own 'value'
-        # needs to be fixed in some better way
-        return $self->value;
     }
     return '';
 }


### PR DESCRIPTION
This was found via a field which had an undefined value that I wished to
transform before rendering.  When the value is undefined, it was being
passed through unchanged; because it is set (has_value is true), the
field default could be used as a substitute either. :(


All tests pass, although I did not add a new test to cover this usecase that is being changed.