### PR TITLE
Text validations were being tested in input, not value!

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+
+   Fixed Text validation checking, to allow deflations and transformations
+   to be applied first.
+
 0.40066 Mon Jul 18, 2016
    Improve Select field option list support
    Support arrayref-of-arrayref options in a subroutine

--- a/lib/HTML/FormHandler/Field/Text.pm
+++ b/lib/HTML/FormHandler/Field/Text.pm
@@ -40,7 +40,7 @@ sub validate {
     my $field = shift;
 
     return unless $field->next::method;
-    my $value = $field->input;
+    my $value = $field->value;
     # Check for max length
     if ( my $maxlength = $field->maxlength ) {
         return $field->add_error( $field->get_message('text_maxlength'),


### PR DESCRIPTION
This means that any defined transform or deflation could not alter the
value to something that would validate.