### PR TITLE
accept coderefs for date_start, date_end in Date field

### DIFF
--- a/t/fields/dates.t
+++ b/t/fields/dates.t
@@ -63,7 +63,7 @@ is( $field->fif, '08/01/2009', 'Correct value' );
 
 $field->clear_date_start;
 $field->reset_result;
-$field->date_end('2010-01-01');
+$field->date_end(sub { '2010-01-01' });
 $field->_set_input('02/01/2010');
 $field->validate_field;
 ok( $field->has_errors, 'date is too late');


### PR DESCRIPTION
This allows the boundaries to be recalculated every time the form is
processed, rather than once up front when the form is declared -- the
difference is relevant for long-running code.