### PR TITLE
Handle 'result' being garbage-collected

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+
+   - Crypt::* and MIME::Base64 prereqs added in last release are moved to
+     optional prereqs
+
 0.40068 Thu Jul 20, 2017
    Add RequestToken field
    Add build_render_list_method

--- a/Changes
+++ b/Changes
@@ -1,7 +1,7 @@
 0.40068 Thu Jul 20, 2017
    Add RequestToken field
    Add build_render_list_method
-   Zccept coderefs for date_start, date_end in Date field
+   Accept coderefs for date_start, date_end in Date field
 
 0.40067 Wed Oct 19, 2016
    Fixed Text validation checking, to allow deflations and transformations

--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 
+   - Fix exception when field 'result' has been garbage-collected
    - Crypt::* and MIME::Base64 prereqs added in last release are moved to
      optional prereqs
 

--- a/dist.ini
+++ b/dist.ini
@@ -57,6 +57,8 @@ Data::Clone                = 0
 JSON::MaybeXS              = 1.003003
 List::Util                 = 1.33
 HTML::Entities             = 0
+
+[Prereqs / RuntimeRecommends]
 Crypt::CBC                 = 0
 Crypt::Blowfish            = 0
 MIME::Base64               = 0
@@ -68,4 +70,5 @@ Test::Exception            = 0
 Test::Memory::Cycle        = 1.04
 Test::Warn                 = 0
 PadWalker                  = 0
+Test::Needs                = 0
 

--- a/lib/HTML/FormHandler/Field.pm
+++ b/lib/HTML/FormHandler/Field.pm
@@ -579,7 +579,7 @@ has 'result' => (
     is        => 'ro',
     weak_ref  => 1,
     clearer   => 'clear_result',
-    predicate => 'has_result',
+    predicate => 'has_result',  # warning: will still return true if value has been garbage-collected
     writer    => '_set_result',
     handles   => [
         '_set_input',   '_clear_input', '_set_value', '_clear_value',
@@ -592,13 +592,13 @@ has '_pin_result' => ( is => 'ro', reader => '_get_pin_result', writer => '_set_
 
 sub has_input {
     my $self = shift;
-    return unless $self->has_result;
+    return unless $self->has_result and $self->result;
     return $self->result->has_input;
 }
 
 sub has_value {
     my $self = shift;
-    return unless $self->has_result;
+    return unless $self->has_result and $self->result;
     return $self->result->has_value;
 }
 
@@ -627,6 +627,7 @@ sub input {
     # allow testing fields individually by creating result if no form
     return undef unless $self->has_result || !$self->form;
     my $result = $self->result;
+    return undef unless $result;
     return $result->_set_input(@_) if @_;
     return $result->input;
 }
@@ -669,6 +670,7 @@ sub fif {
     return '' if $self->password;
     return unless $result || $self->has_result;
     my $lresult = $result || $self->result;
+    return unless $lresult;
     if ( ( $self->has_result && $self->has_input && !$self->fif_from_value ) ||
         ( $self->fif_from_value && !defined $lresult->value ) )
     {

--- a/t/fields/request_token.t
+++ b/t/fields/request_token.t
@@ -2,6 +2,8 @@ use strict;
 use warnings;
 use Test::More;
 
+use Test::Needs qw(Crypt::CBC Crypt::Blowfish MIME::Base64);
+
 {
     package MyApp::Form::Test;
     use HTML::FormHandler::Moose;


### PR DESCRIPTION
The 'result' attribute can be garbage-collected, but $field->has_result still returns true. We also need to check that $field->result is still defined.

This PR also makes optional the prereqs that were added in the last release, as Crypt::CBC doesn't install on all systems and is only necessary for the one new Field type.