### PR TITLE
fix: validate_model should not be called to validate a field named 'model'

### DIFF
--- a/lib/HTML/FormHandler/Field.pm
+++ b/lib/HTML/FormHandler/Field.pm
@@ -1063,7 +1063,7 @@ sub build_validate_method {
     my $set_validate = $self->set_validate;
     $set_validate ||= "validate_" . convert_full_name($self->full_name);
     return sub { my $self = shift; $self->form->$set_validate($self); }
-        if ( $self->form && $self->form->can($set_validate) );
+        if ( $set_validate ne 'validate_model' && $self->form && $self->form->can($set_validate) );
     return sub { };
 }
 


### PR DESCRIPTION
In HTML::FormHandler::Field build_validate_method looks for a method "validate_$name" even if the field name is 'model', so validate_model is called when validating field. The PR avoids this behaviour.