### PR TITLE
avoid conditional variable declaration

### DIFF
--- a/lib/HTML/FormHandler/Field.pm
+++ b/lib/HTML/FormHandler/Field.pm
@@ -610,7 +610,8 @@ sub reset_result {
 }
 sub build_result {
     my $self = shift;
-    my @parent = ( 'parent' => $self->parent->result )
+    my @parent;
+    @parent = ( 'parent' => $self->parent->result )
         if ( $self->parent && $self->parent->result );
     my $result = HTML::FormHandler::Field::Result->new(
         name      => $self->name,
@@ -939,7 +940,8 @@ sub element_wrapper_attributes {
     $self->add_standard_element_wrapper_classes( $result, $class );
     $attr->{class} = $class if @$class;
     # call form hook
-    my $mod_attr = $self->form->html_attributes($self, 'element_wrapper', $attr, $result) if $self->form;
+    my $mod_attr;
+    $mod_attr = $self->form->html_attributes($self, 'element_wrapper', $attr, $result) if $self->form;
     return ref($mod_attr) eq 'HASH' ? $mod_attr : $attr;
 }
 sub add_standard_element_wrapper_classes {
@@ -969,7 +971,8 @@ sub element_attributes {
     $self->add_standard_element_classes($result, $class);
     $attr->{class} = $class if @$class;
     # call form hook
-    my $mod_attr = $self->form->html_attributes($self, 'element', $attr, $result) if $self->form;
+    my $mod_attr;
+    $mod_attr = $self->form->html_attributes($self, 'element', $attr, $result) if $self->form;
     return ref($mod_attr) eq 'HASH' ? $mod_attr : $attr;
 }
 
@@ -989,7 +992,8 @@ sub label_attributes {
     $self->add_standard_label_classes($result, $class);
     $attr->{class} = $class if @$class;
     # call form hook
-    my $mod_attr = $self->form->html_attributes($self, 'label', $attr, $result) if $self->form;
+    my $mod_attr;
+    $mod_attr = $self->form->html_attributes($self, 'label', $attr, $result) if $self->form;
     return ref($mod_attr) eq 'HASH' ? $mod_attr : $attr;
 }
 
@@ -1010,7 +1014,8 @@ sub wrapper_attributes {
     $attr->{id} = $self->id
         if ( $self->has_flag('is_compound') && not exists $attr->{id} && ! $self->get_tag('no_wrapper_id') );
     # call form hook
-    my $mod_attr = $self->form->html_attributes($self, 'wrapper', $attr, $result) if $self->form;
+    my $mod_attr;
+    $mod_attr = $self->form->html_attributes($self, 'wrapper', $attr, $result) if $self->form;
     return ref($mod_attr) eq 'HASH' ? $mod_attr : $attr;
 }
 


### PR DESCRIPTION
perldoc perlsyn:

> The behaviour of a `my`, `state`, or `our` modified with a statement modifier conditional or loop construct (for example, `my $x if ... `) is **undefined**.