### PR TITLE
avoid conditional variable declaration

### DIFF
--- a/lib/HTML/FormHandler/InitResult.pm
+++ b/lib/HTML/FormHandler/InitResult.pm
@@ -102,7 +102,8 @@ sub _result_from_object {
             $result = $field->_result_from_fields($result) unless $found;
         }
         else {
-           my $value = $self->_get_value( $field, $item ) unless $field->writeonly;
+           my $value;
+           $value = $self->_get_value( $field, $item ) unless $field->writeonly;
            $result = $field->_result_from_object( $result, $value );
         }
         $self_result->add_result($result) if $result;


### PR DESCRIPTION
perldoc perlsyn:

> The behaviour of a `my`, `state`, or `our` modified with a statement modifier conditional or loop construct (for example, `my $x if ...` ) is **undefined**.