### PR TITLE
avoid conditional variable declaration

### DIFF
--- a/lib/HTML/FormHandler/Widget/Wrapper/Bootstrap.pm
+++ b/lib/HTML/FormHandler/Widget/Wrapper/Bootstrap.pm
@@ -41,7 +41,7 @@ sub wrap_field {
 
     my $output;
     # is this a control group or a form action?
-    my $form_actions = 1 if ( $self->name eq 'form_actions' || $self->type_attr eq 'submit'
+    my $form_actions = ( $self->name eq 'form_actions' || $self->type_attr eq 'submit'
         || $self->type_attr eq 'reset' );
     # create attribute string for wrapper
     my $attr = $self->wrapper_attributes($result);


### PR DESCRIPTION
perldoc perlsyn:

> The behaviour of a `my`, `state`, or `our` modified with a statement modifier conditional or loop construct (for example, `my $x if ...` ) is **undefined**.