### PR TITLE
Drop dependency on aliased

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -44,7 +44,6 @@ MooseX::Getopt             = 0.16
 MooseX::Types              = 0.20
 MooseX::Types::Common      = 0
 MooseX::Types::LoadableClass = 0.006
-aliased                    = 0
 File::Spec                 = 0
 File::ShareDir             = 0
 Try::Tiny                  = 0

--- a/lib/HTML/FormHandler/Field/Repeatable.pm
+++ b/lib/HTML/FormHandler/Field/Repeatable.pm
@@ -4,7 +4,7 @@ package HTML::FormHandler::Field::Repeatable;
 use Moose;
 extends 'HTML::FormHandler::Field::Compound';
 
-use aliased 'HTML::FormHandler::Field::Repeatable::Instance';
+use HTML::FormHandler::Field::Repeatable::Instance;
 use HTML::FormHandler::Field::PrimaryKey;
 use HTML::FormHandler::Merge ('merge');
 use Data::Clone ('data_clone');
@@ -228,7 +228,7 @@ sub create_element {
             $instance_attr );
     }
     else {
-        $instance = Instance->new( %$instance_attr );
+        $instance = HTML::FormHandler::Field::Repeatable::Instance->new( %$instance_attr );
     }
     # copy the fields from this field into the instance
     $instance->add_field( $self->all_fields );


### PR DESCRIPTION
It's a non core module, the use of which is so minimal that it doesn't really buy us anything. So just drop it and reduce the weight :-)