### PR TITLE
Remove unused dep MooseX::Getopt

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -40,7 +40,6 @@ Moose                      = 2.1403
 Locale::Maketext           = 1.09
 DateTime                   = 0
 DateTime::Format::Strptime = 0
-MooseX::Getopt             = 0.16
 MooseX::Types              = 0.20
 MooseX::Types::Common      = 0
 MooseX::Types::LoadableClass = 0.006


### PR DESCRIPTION
The last usage was removed way back in '09 with:

```
commit efdc892562077fdfad0d1fa6a42f6530b369cb11
Author: Gerda Shank <gerda.shank@gmail.com>
Date:   Sat Jul 25 14:07:55 2009 -0400

    rm leftover Generator::DBIC
```